### PR TITLE
Be tolerant with yaml and yml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     kotlin("jvm") version "1.3.70"
 }
 
-version = "1.1.1"
+version = "1.1.2"
 group = "com.saagie"
 
 config {

--- a/src/main/kotlin/com/saagie/technologies/Extensions.kt
+++ b/src/main/kotlin/com/saagie/technologies/Extensions.kt
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2020 Pierre Leresteux.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.saagie.technologies
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+fun File.checkYamlExtension() =
+    this.path
+        .replace(".yaml", "")
+        .replace(".yml", "")
+        .let { path ->
+            when {
+                Files.exists(Paths.get("$path.yaml")) -> Paths.get("$path.yaml").toFile()
+                Files.exists(Paths.get("$path.yml")) -> Paths.get("$path.yml").toFile()
+                else -> this
+            }
+    }
+
+fun Path.checkYamlExtension() = this.toFile().checkYamlExtension().toPath()
+
+fun String.checkYamlExtension() = Paths.get(this).checkYamlExtension().toUri().path

--- a/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesGradlePlugin.kt
+++ b/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesGradlePlugin.kt
@@ -17,11 +17,7 @@
  */
 package com.saagie.technologies
 
-import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerWaitContainer
+import com.bmuschko.gradle.docker.tasks.container.*
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
@@ -62,10 +58,11 @@ class SaagieTechnologiesGradlePlugin : Plugin<Project> {
             dependsOn(pullDockerImage)
             targetImageId(imageTestName)
             hostConfig.autoRemove.set(false)
-            hostConfig.binds.put("${project.projectDir.absolutePath}/image_test.yml", "/workdir/image_test.yml")
             hostConfig.binds.put("/var/run/docker.sock", "/var/run/docker.sock")
             workingDir.set("/workdir")
-            cmd.addAll("test", "--image", imageName, "--config", "/workdir/image_test.yml")
+            val imageTestFile = "${project.projectDir.absolutePath}/image_test".checkYamlExtension()
+            hostConfig.binds.put(imageTestFile, "/workdir/image_test.yaml")
+            cmd.addAll("test", "--image", imageName, "--config", "/workdir/image_test.yaml")
         }
 
         val startContainer = project.tasks.create<DockerStartContainer>("startContainer") {

--- a/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesMetadata.kt
+++ b/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesMetadata.kt
@@ -27,13 +27,13 @@ import com.saagie.technologies.model.ContextMetadata
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import java.io.File
-import java.util.Optional
+import java.util.*
 
 fun generateDockerTag(project: Project, contextMetadata: ContextMetadata) =
     "${contextMetadata.dockerInfo?.image}:${project.generateTag()}"
 
 fun storeMetadata(project: Project, projectDir: File, contextMetadata: ContextMetadata) {
-    val targetMetadata = File("${projectDir.absolutePath}/dockerInfo.yml")
+    val targetMetadata = File("${projectDir.absolutePath}/dockerInfo.yaml").checkYamlExtension()
     targetMetadata.delete()
     targetMetadata.appendText(
         getJacksonObjectMapper().writeValueAsString(
@@ -46,7 +46,9 @@ fun storeMetadata(project: Project, projectDir: File, contextMetadata: ContextMe
 
 fun readContextMetadata(projectDir: File): ContextMetadata =
     getJacksonObjectMapper().readValue(
-        File("${projectDir.absoluteFile}/context.yml").inputStream(),
+        File("${projectDir.absoluteFile}/context.yaml")
+            .checkYamlExtension()
+            .inputStream(),
         ContextMetadata::class.java
     )
 

--- a/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesUtils.kt
+++ b/src/main/kotlin/com/saagie/technologies/SaagieTechnologiesUtils.kt
@@ -25,19 +25,25 @@ enum class TYPE(val folderName: String) {
     APP("app")
 }
 
-fun File.isADirectoryContainingFile(fileName: String): Boolean = this.isDirectory && File(this.absolutePath + "/$fileName").exists()
+fun File.isADirectoryContainingFile(fileName: String): Boolean =
+    this.isDirectory &&
+            (
+                    File(this.absolutePath + "/$fileName.yaml").exists() ||
+                            File(this.absolutePath + "/$fileName.yml").exists()
+                    )
+
 fun String.isA(type: TYPE): Boolean = this.contains("/" + type.folderName + "/")
 
 fun modifiedProjects(type: TYPE, subProjects: MutableSet<Project>): Set<Project> {
     val listModifiedProjects = mutableSetOf<Project>()
 
     Runtime.getRuntime().exec(
-        arrayOf(
-            "bash",
-            "-c",
-            "git diff --name-only  origin/master..."
-        )
-    ).inputStream.bufferedReader().readText()
+            arrayOf(
+                "bash",
+                "-c",
+                "git diff --name-only  origin/master..."
+            )
+        ).inputStream.bufferedReader().readText()
         .split("\n").dropLast(1)
         .forEach { pathFile ->
             if (pathFile.isA(type) && (File(pathFile).isFile || !File(pathFile).exists())) {

--- a/src/test/kotlin/com/saagie/technologies/SaagieTechnologiesGradlePluginKtTest.kt
+++ b/src/test/kotlin/com/saagie/technologies/SaagieTechnologiesGradlePluginKtTest.kt
@@ -92,7 +92,7 @@ class SaagieTechnologiesGradlePluginKtTest {
                 this.version = "1.2.3"
                 val contextMetadata = ContextMetadata(MetadataDocker("nginx", "1.2.3"))
                 storeMetadata(project, projectDir, contextMetadata)
-                val metadataFinalFile = File("${project.projectDir.absolutePath}/dockerInfo.yml")
+                val metadataFinalFile = File("${project.projectDir.absolutePath}/dockerInfo.yaml")
                 assertTrue(metadataFinalFile.exists())
                 assertEquals(
                     """dockerInfo:


### PR DESCRIPTION
`yaml` should be the YAML extension (all generated files used yaml now)

But the plugin is tolerant ... and if a file is a yml extension, it's ok ... 